### PR TITLE
lib/libusb/libusb.h: Fixed the link of the description

### DIFF
--- a/lib/libusb/libusb.h
+++ b/lib/libusb/libusb.h
@@ -245,7 +245,7 @@ enum libusb_log_level {
 /* XXX */
 /* libusb_set_debug should take parameters from libusb_log_level
  * above according to
- *   http://libusb.sourceforge.net/api-1.0/group__lib.html
+ *   https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html
  */
 enum libusb_debug_level {
 	LIBUSB_DEBUG_NO=0,


### PR DESCRIPTION
name: Ting-Hsuan Huang
email: felixhuang07@gmail.com
`line 248` in `lib/libusb/libusb.h`:
The original link was incorrect, it shows the following result:
![image](https://github.com/fffelix-huang/freebsd-src/assets/72808219/c1625aa2-550f-4e11-8a75-c120e1ec99a5)
We have found the correct link to it, which is [this](https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html).

Event: from the Advanced UNIX Programming Course (Fall’23) at NTHU.